### PR TITLE
允许蛇追尾并修复可用空间计算

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,7 +27,7 @@ export default function Home() {
           <ul className="space-y-2 text-sm text-gray-600 dark:text-gray-300">
             <li>• <strong>神经网络</strong>：AI通过多层神经元处理游戏状态</li>
             <li>• <strong>强化学习</strong>：AI通过试错不断改进策略</li>
-            <li>• <strong>进化算法</strong>：表现好的AI会"繁殖"并变异</li>
+            <li>• <strong>进化算法</strong>：表现好的AI会“繁殖”并变异</li>
             <li>• <strong>实时可视化</strong>：观看AI的学习过程和进步轨迹</li>
           </ul>
         </div>

--- a/src/app/snake-ai/page.tsx
+++ b/src/app/snake-ai/page.tsx
@@ -7,10 +7,12 @@ interface Position {
   y: number;
 }
 
+type Direction = 'UP' | 'DOWN' | 'LEFT' | 'RIGHT';
+
 interface GameState {
   snake: Position[];
   food: Position;
-  direction: string;
+  direction: Direction;
   score: number;
   gameOver: boolean;
 }
@@ -29,6 +31,19 @@ interface AIStats {
 
 const GRID_SIZE = 20;
 const CANVAS_SIZE = 400;
+const DIRECTIONS: Direction[] = ['UP', 'DOWN', 'LEFT', 'RIGHT'];
+const DIRECTION_OFFSETS: Record<Direction, { dx: number; dy: number }> = {
+  UP: { dx: 0, dy: -1 },
+  DOWN: { dx: 0, dy: 1 },
+  LEFT: { dx: -1, dy: 0 },
+  RIGHT: { dx: 1, dy: 0 }
+};
+const OPPOSITE_DIRECTION: Record<Direction, Direction> = {
+  UP: 'DOWN',
+  DOWN: 'UP',
+  LEFT: 'RIGHT',
+  RIGHT: 'LEFT'
+};
 
 class NeuralNetwork {
   weights1: number[][];
@@ -211,12 +226,11 @@ export default function SnakeAI() {
   const gameHistoryRef = useRef<number[]>([]);
   const stepsWithoutFoodRef = useRef(0);
 
-  const directions = ['UP', 'DOWN', 'LEFT', 'RIGHT'];
-
   const getGameInputs = useCallback((state: GameState): number[] => {
     const head = state.snake[0];
     const food = state.food;
     const inputs: number[] = [];
+    const snakeSet = new Set(state.snake.map(seg => `${seg.x},${seg.y}`));
 
     const foodDx = food.x - head.x;
     const foodDy = food.y - head.y;
@@ -241,49 +255,43 @@ export default function SnakeAI() {
         if (dx === 0 && dy === 0) continue;
         const checkX = head.x + dx;
         const checkY = head.y + dy;
-        const hasBody = state.snake.some(seg => seg.x === checkX && seg.y === checkY);
+        const hasBody = snakeSet.has(`${checkX},${checkY}`);
         bodyDensityAround.push(hasBody ? 1 : 0);
       }
     }
     inputs.push(...bodyDensityAround.slice(0, 8)); // 只取前8个最重要的
 
-    const directions = [
-      { dx: 0, dy: -1, name: 'UP' },
-      { dx: 0, dy: 1, name: 'DOWN' }, 
-      { dx: -1, dy: 0, name: 'LEFT' },
-      { dx: 1, dy: 0, name: 'RIGHT' }
-    ];
-
     // 多步路径安全检查
-    for (const dir of directions) {
+    for (const dir of DIRECTIONS) {
+      const offset = DIRECTION_OFFSETS[dir];
       let safeSteps = 0;
       let foundFood = false;
-      
+
       // 检查这个方向上连续几步都安全
       for (let step = 1; step <= 5; step++) {
-        const checkX = head.x + dir.dx * step;
-        const checkY = head.y + dir.dy * step;
-        
+        const checkX = head.x + offset.dx * step;
+        const checkY = head.y + offset.dy * step;
+
         if (checkX < 0 || checkX >= GRID_SIZE || checkY < 0 || checkY >= GRID_SIZE) {
           break;
         }
-        
-        if (state.snake.some(seg => seg.x === checkX && seg.y === checkY)) {
+
+        if (snakeSet.has(`${checkX},${checkY}`)) {
           break;
         }
-        
+
         safeSteps = step;
-        
+
         if (checkX === food.x && checkY === food.y) {
           foundFood = true;
           break;
         }
       }
-      
+
       inputs.push(
         safeSteps / 5.0, // 安全步数比例
         foundFood ? 1 : 0, // 这个方向能到食物
-        state.direction === dir.name ? 1 : 0 // 当前方向
+        state.direction === dir ? 1 : 0 // 当前方向
       );
     }
 
@@ -317,13 +325,9 @@ export default function SnakeAI() {
 
   const moveSnake = useCallback((state: GameState): GameState => {
     const head = { ...state.snake[0] };
-
-    switch (state.direction) {
-      case 'UP': head.y -= 1; break;
-      case 'DOWN': head.y += 1; break;
-      case 'LEFT': head.x -= 1; break;
-      case 'RIGHT': head.x += 1; break;
-    }
+    const offset = DIRECTION_OFFSETS[state.direction];
+    head.x += offset.dx;
+    head.y += offset.dy;
 
     if (head.x < 0 || head.x >= GRID_SIZE || head.y < 0 || head.y >= GRID_SIZE) {
       return { ...state, gameOver: true };
@@ -361,16 +365,10 @@ export default function SnakeAI() {
     };
   }, [generateFood]);
 
-  const evaluateDirection = useCallback((state: GameState, direction: string): number => {
+  const evaluateDirection = useCallback((state: GameState, direction: Direction): number => {
     const head = state.snake[0];
-    const newHead = { ...head };
-
-    switch (direction) {
-      case 'UP': newHead.y -= 1; break;
-      case 'DOWN': newHead.y += 1; break;
-      case 'LEFT': newHead.x -= 1; break;
-      case 'RIGHT': newHead.x += 1; break;
-    }
+    const offset = DIRECTION_OFFSETS[direction];
+    const newHead = { x: head.x + offset.dx, y: head.y + offset.dy };
     
     let score = 0;
     
@@ -388,12 +386,7 @@ export default function SnakeAI() {
     }
 
     // 反向移动扣分
-    const isOppositeDirection =
-      (state.direction === 'UP' && direction === 'DOWN') ||
-      (state.direction === 'DOWN' && direction === 'UP') ||
-      (state.direction === 'LEFT' && direction === 'RIGHT') ||
-      (state.direction === 'RIGHT' && direction === 'LEFT');
-    if (isOppositeDirection) return -1500;
+    if (OPPOSITE_DIRECTION[state.direction] === direction) return -1500;
 
     const futureSnake = willEat
       ? [newHead, ...state.snake]
@@ -429,17 +422,12 @@ export default function SnakeAI() {
     // 长期路径规划 - 检查前方5步的安全性
     let continuousSteps = 0;
     for (let step = 1; step <= 5; step++) {
-      const checkHead = { ...newHead };
-      switch (direction) {
-        case 'UP': checkHead.y -= step; break;
-        case 'DOWN': checkHead.y += step; break;
-        case 'LEFT': checkHead.x -= step; break;
-        case 'RIGHT': checkHead.x += step; break;
-      }
+      const checkX = newHead.x + offset.dx * step;
+      const checkY = newHead.y + offset.dy * step;
 
-      if (checkHead.x < 0 || checkHead.x >= GRID_SIZE ||
-          checkHead.y < 0 || checkHead.y >= GRID_SIZE ||
-          futureSnakeSet.has(`${checkHead.x},${checkHead.y}`)) {
+      if (checkX < 0 || checkX >= GRID_SIZE ||
+          checkY < 0 || checkY >= GRID_SIZE ||
+          futureSnakeSet.has(`${checkX},${checkY}`)) {
         break;
       }
       continuousSteps++;
@@ -457,7 +445,7 @@ export default function SnakeAI() {
     }
     
     return score;
-  }, []);
+  }, [calculateFreeSpace, calculateTrapRisk]);
 
   const calculateFreeSpace = useCallback((pos: Position, snake: Position[]): number => {
     let freeCount = 0;
@@ -495,25 +483,30 @@ export default function SnakeAI() {
 
   const calculateTrapRisk = useCallback((pos: Position, snake: Position[]): number => {
     let surroundingBodyCount = 0;
+    const snakeSet = new Set(snake.map(seg => `${seg.x},${seg.y}`));
     const checkPositions = [
       {x: pos.x + 1, y: pos.y}, {x: pos.x - 1, y: pos.y},
       {x: pos.x, y: pos.y + 1}, {x: pos.x, y: pos.y - 1},
       {x: pos.x + 1, y: pos.y + 1}, {x: pos.x - 1, y: pos.y - 1},
       {x: pos.x + 1, y: pos.y - 1}, {x: pos.x - 1, y: pos.y + 1}
     ];
-    
+
     for (const checkPos of checkPositions) {
-      if (checkPos.x < 0 || checkPos.x >= GRID_SIZE || 
-          checkPos.y < 0 || checkPos.y >= GRID_SIZE ||
-          snake.some(seg => seg.x === checkPos.x && seg.y === checkPos.y)) {
+      if (checkPos.x < 0 || checkPos.x >= GRID_SIZE ||
+          checkPos.y < 0 || checkPos.y >= GRID_SIZE) {
+        surroundingBodyCount++;
+        continue;
+      }
+
+      if (snakeSet.has(`${checkPos.x},${checkPos.y}`)) {
         surroundingBodyCount++;
       }
     }
-    
+
     return surroundingBodyCount / 8.0; // 返回0-1的风险值
   }, []);
 
-  const getAIDirection = useCallback((state: GameState): string => {
+  const getAIDirection = useCallback((state: GameState): Direction => {
     const inputs = getGameInputs(state);
     const outputs = neuralNetRef.current.predict(inputs);
     
@@ -523,7 +516,7 @@ export default function SnakeAI() {
     const trapRisk = calculateTrapRisk(head, state.snake);
     const safetyMode = freeSpace < 4 || trapRisk > 0.5;
     
-    const directionScores = directions.map((dir, index) => ({
+    const directionScores = DIRECTIONS.map((dir, index) => ({
       dir,
       aiScore: outputs[index] * 100,
       safetyScore: evaluateDirection(state, dir),
@@ -538,7 +531,7 @@ export default function SnakeAI() {
     // 过滤出安全方向
     const safeDirs = directionScores.filter(d => d.safetyScore > -500);
     
-    let chosenDirection;
+    let chosenDirection: Direction = state.direction;
     let decision = '';
     
     if (safeDirs.length === 0) {

--- a/src/app/snake-ai/page.tsx
+++ b/src/app/snake-ai/page.tsx
@@ -84,7 +84,7 @@ class NeuralNetwork {
   }
 
   predict(inputs: number[]): number[] {
-    let layer1 = Array(24).fill(0);
+    const layer1 = Array(24).fill(0);
     for (let i = 0; i < 24; i++) {
       let sum = this.bias1[i];
       for (let j = 0; j < inputs.length; j++) {
@@ -93,7 +93,7 @@ class NeuralNetwork {
       layer1[i] = this.relu(sum);
     }
 
-    let layer2 = Array(16).fill(0);
+    const layer2 = Array(16).fill(0);
     for (let i = 0; i < 16; i++) {
       let sum = this.bias2[i];
       for (let j = 0; j < layer1.length; j++) {
@@ -102,7 +102,7 @@ class NeuralNetwork {
       layer2[i] = this.relu(sum);
     }
 
-    let output = Array(4).fill(0);
+    const output = Array(4).fill(0);
     for (let i = 0; i < 4; i++) {
       let sum = this.bias3[i];
       for (let j = 0; j < layer2.length; j++) {
@@ -317,7 +317,7 @@ export default function SnakeAI() {
 
   const moveSnake = useCallback((state: GameState): GameState => {
     const head = { ...state.snake[0] };
-    
+
     switch (state.direction) {
       case 'UP': head.y -= 1; break;
       case 'DOWN': head.y += 1; break;
@@ -329,7 +329,10 @@ export default function SnakeAI() {
       return { ...state, gameOver: true };
     }
 
-    if (state.snake.some(segment => segment.x === head.x && segment.y === head.y)) {
+    const willEat = head.x === state.food.x && head.y === state.food.y;
+    const bodyToCheck = willEat ? state.snake : state.snake.slice(0, -1);
+
+    if (bodyToCheck.some(segment => segment.x === head.x && segment.y === head.y)) {
       return { ...state, gameOver: true };
     }
 
@@ -337,7 +340,7 @@ export default function SnakeAI() {
     let newFood = state.food;
     let newScore = state.score;
 
-    if (head.x === state.food.x && head.y === state.food.y) {
+    if (willEat) {
       newScore += 10;
       newFood = generateFood(newSnake);
       stepsWithoutFoodRef.current = 0;
@@ -360,8 +363,8 @@ export default function SnakeAI() {
 
   const evaluateDirection = useCallback((state: GameState, direction: string): number => {
     const head = state.snake[0];
-    let newHead = { ...head };
-    
+    const newHead = { ...head };
+
     switch (direction) {
       case 'UP': newHead.y -= 1; break;
       case 'DOWN': newHead.y += 1; break;
@@ -376,25 +379,33 @@ export default function SnakeAI() {
       return -2000;
     }
     
+    const willEat = newHead.x === state.food.x && newHead.y === state.food.y;
+    const bodyToCheck = willEat ? state.snake : state.snake.slice(0, -1);
+
     // 撞自己严重扣分
-    if (state.snake.some(segment => segment.x === newHead.x && segment.y === newHead.y)) {
+    if (bodyToCheck.some(segment => segment.x === newHead.x && segment.y === newHead.y)) {
       return -2000;
     }
-    
+
     // 反向移动扣分
-    const isOppositeDirection = 
+    const isOppositeDirection =
       (state.direction === 'UP' && direction === 'DOWN') ||
       (state.direction === 'DOWN' && direction === 'UP') ||
       (state.direction === 'LEFT' && direction === 'RIGHT') ||
       (state.direction === 'RIGHT' && direction === 'LEFT');
     if (isOppositeDirection) return -1500;
-    
+
+    const futureSnake = willEat
+      ? [newHead, ...state.snake]
+      : [newHead, ...state.snake.slice(0, -1)];
+    const futureSnakeSet = new Set(futureSnake.map(seg => `${seg.x},${seg.y}`));
+
     // 空间感知 - 评估移动后的可用空间
-    const freeSpaceAfterMove = calculateFreeSpace(newHead, state.snake);
+    const freeSpaceAfterMove = calculateFreeSpace(newHead, futureSnake);
     score += freeSpaceAfterMove * 10;
-    
+
     // 身体陷阱检测 - 检查是否会被自己身体包围
-    const trapRisk = calculateTrapRisk(newHead, state.snake);
+    const trapRisk = calculateTrapRisk(newHead, futureSnake);
     score -= trapRisk * 200;
     
     // 食物追逐策略 - 但不能过于激进
@@ -418,27 +429,27 @@ export default function SnakeAI() {
     // 长期路径规划 - 检查前方5步的安全性
     let continuousSteps = 0;
     for (let step = 1; step <= 5; step++) {
-      let checkHead = { ...newHead };
+      const checkHead = { ...newHead };
       switch (direction) {
         case 'UP': checkHead.y -= step; break;
         case 'DOWN': checkHead.y += step; break;
         case 'LEFT': checkHead.x -= step; break;
         case 'RIGHT': checkHead.x += step; break;
       }
-      
-      if (checkHead.x < 0 || checkHead.x >= GRID_SIZE || 
+
+      if (checkHead.x < 0 || checkHead.x >= GRID_SIZE ||
           checkHead.y < 0 || checkHead.y >= GRID_SIZE ||
-          state.snake.some(segment => segment.x === checkHead.x && segment.y === checkHead.y)) {
+          futureSnakeSet.has(`${checkHead.x},${checkHead.y}`)) {
         break;
       }
       continuousSteps++;
     }
-    
+
     score += continuousSteps * 30; // 能走得越远越好
-    
+
     // 尾巴跟随策略 - 有时跟着尾巴走是安全的
-    if (state.snake.length > 4) {
-      const tail = state.snake[state.snake.length - 1];
+    if (futureSnake.length > 4) {
+      const tail = futureSnake[futureSnake.length - 1];
       const distToTail = Math.abs(newHead.x - tail.x) + Math.abs(newHead.y - tail.y);
       if (distToTail <= 2 && freeSpaceAfterMove < 4) {
         score += 60; // 靠近尾巴在狭窄空间是好策略
@@ -452,22 +463,24 @@ export default function SnakeAI() {
     let freeCount = 0;
     const visited = new Set<string>();
     const queue = [pos];
-    
+    const snakeSet = new Set(snake.map(seg => `${seg.x},${seg.y}`));
+    const startKey = `${pos.x},${pos.y}`;
+
     while (queue.length > 0 && freeCount < 15) { // 限制搜索范围
       const current = queue.shift()!;
       const key = `${current.x},${current.y}`;
-      
+
       if (visited.has(key)) continue;
       visited.add(key);
-      
-      if (current.x < 0 || current.x >= GRID_SIZE || 
+
+      if (current.x < 0 || current.x >= GRID_SIZE ||
           current.y < 0 || current.y >= GRID_SIZE ||
-          snake.some(seg => seg.x === current.x && seg.y === current.y)) {
+          (snakeSet.has(key) && key !== startKey)) {
         continue;
       }
-      
+
       freeCount++;
-      
+
       // 添加邻居
       queue.push(
         {x: current.x + 1, y: current.y},
@@ -476,7 +489,7 @@ export default function SnakeAI() {
         {x: current.x, y: current.y - 1}
       );
     }
-    
+
     return freeCount;
   }, []);
 


### PR DESCRIPTION
## Summary
- 修复 moveSnake 与 evaluateDirection 的自撞逻辑，让蛇在尾巴收缩时可以安全追尾，并基于移动后的蛇身进行评分
- 调整 calculateFreeSpace，跳过起点并使用集合加速碰撞判断，避免把蛇头算作障碍
- 修正首页文案中的引号写法以满足 ESLint 规则

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ccf59d43988324aeea2fa1b987d80a